### PR TITLE
Make all of api.github.com allowed

### DIFF
--- a/superawesomesites.txt
+++ b/superawesomesites.txt
@@ -138,7 +138,6 @@ inbots.zoom.us
 github.com/login/*
 github.com/session
 github.com/enterprises/portswigger-emu/*
-api.github.com/user
-api.github.com/coilot_internal/*
+api.github.com
 origin-tracker.githubusercontent.com
 *.githubcopilot.com


### PR DESCRIPTION
This seems to be needed to retrieve github device code