### PR TITLE
Add testphp.vulnweb.com

### DIFF
--- a/superawesomesites.txt
+++ b/superawesomesites.txt
@@ -154,3 +154,4 @@ ginandjuice.shop
 packages.jetbrains.team/maven/p/ij/intellij-redist/*
 inbots.zoom.us
 js.stripe.com/*
+testphp.vulnweb.com


### PR DESCRIPTION
https://testphp.vulnweb.com/ is a vulnerable PHP application intended for testing Acunetix. I need access to scan this as part of a customer case.