### PR TITLE
Add Swagger github repository

### DIFF
--- a/superawesomesites.txt
+++ b/superawesomesites.txt
@@ -107,6 +107,7 @@ github.com/sdkman/sdkman-cli-native/releases/download/*
 github.com/sdkman/sdkman-cli/releases/download/*
 github.com/session
 github.com/sso_login
+github.com/swagger-api/
 *.go.dev
 vscode.dev
 bugs.nist.gov


### PR DESCRIPTION
To startup the local version of swagger petstore, the mvn package does a wget to this repo.