### PR TITLE
Add URL for portswigger-cloud helm chart repo

### DIFF
--- a/superawesomesites.txt
+++ b/superawesomesites.txt
@@ -168,3 +168,4 @@ dl.k8s.io/release/*
 pkgs.k8s.io
 amazonlinux.eu-west-1.amazonaws.com/2/*
 github.com/derailed/k9s/releases/download/*
+portswigger-cloud.github.io/helm-charts/


### PR DESCRIPTION
So that we can develop against the actual helm charts we use in production