### PR TITLE
academy/snoopervisor urls

### DIFF
--- a/superawesomesites.txt
+++ b/superawesomesites.txt
@@ -155,3 +155,6 @@ packages.jetbrains.team/maven/p/ij/intellij-redist/*
 inbots.zoom.us
 js.stripe.com/*
 dl-ssl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+dev.snoopervisor.net
+staging.snoopervisor.net
+snoopervisor.net

--- a/superawesomesites.txt
+++ b/superawesomesites.txt
@@ -154,3 +154,4 @@ ginandjuice.shop
 packages.jetbrains.team/maven/p/ij/intellij-redist/*
 inbots.zoom.us
 js.stripe.com/*
+dl-ssl.google.com/linux/direct/google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
To build academy images on our workspaces, we need to download latest stable chrome. I've added the domain + path for that.

Also, it would be helpful to access snoopervisor from workspaces. I've added the domains for them as well.